### PR TITLE
fix for laminas/escaper 2.8

### DIFF
--- a/src/Cloud/Decorator/HtmlTag.php
+++ b/src/Cloud/Decorator/HtmlTag.php
@@ -241,7 +241,7 @@ class HtmlTag extends AbstractTag
 
             $tagHTML  = sprintf(
                 '<a href="%s" %s>%s</a>',
-                $escaper->escapeHtml($tag->getParam('url')),
+                $escaper->escapeHtml($tag->getParam('url') ?? ''),
                 $attribute,
                 $escaper->escapeHtml($tag->getTitle())
             );


### PR DESCRIPTION
since laminas-escape 2.8, test suite is failing

```
1) LaminasTest\Tag\Cloud\CloudTest::testRender
TypeError: Laminas\Escaper\Escaper::escapeHtml(): Argument #1 ($string) must be of type string, null given, called in /dev/shm/BUILDROOT/php-laminas-tag-2.8.0-1.fc33.remi.x86_64/usr/share/php/Laminas/Tag/Cloud/Decorator/HtmlTag.php on line 244
/usr/share/php/Laminas/Escaper/Escaper.php:180
/dev/shm/BUILDROOT/php-laminas-tag-2.8.0-1.fc33.remi.x86_64/usr/share/php/Laminas/Tag/Cloud/Decorator/HtmlTag.php:244
/dev/shm/BUILDROOT/php-laminas-tag-2.8.0-1.fc33.remi.x86_64/usr/share/php/Laminas/Tag/Cloud.php:308
/dev/shm/BUILD/laminas-tag-f8d754c800196375869b7a4fae870ca89ab91bfb/test/Cloud/CloudTest.php:293

2) LaminasTest\Tag\Cloud\CloudTest::testRenderViaToString
TypeError: Laminas\Escaper\Escaper::escapeHtml(): Argument #1 ($string) must be of type string, null given, called in /dev/shm/BUILDROOT/php-laminas-tag-2.8.0-1.fc33.remi.x86_64/usr/share/php/Laminas/Tag/Cloud/Decorator/HtmlTag.php on line 244

/usr/share/php/Laminas/Escaper/Escaper.php:180
/dev/shm/BUILDROOT/php-laminas-tag-2.8.0-1.fc33.remi.x86_64/usr/share/php/Laminas/Tag/Cloud/Decorator/HtmlTag.php:244
/dev/shm/BUILDROOT/php-laminas-tag-2.8.0-1.fc33.remi.x86_64/usr/share/php/Laminas/Tag/Cloud.php:308
/dev/shm/BUILDROOT/php-laminas-tag-2.8.0-1.fc33.remi.x86_64/usr/share/php/Laminas/Tag/Cloud.php:322
/dev/shm/BUILD/laminas-tag-f8d754c800196375869b7a4fae870ca89ab91bfb/test/Cloud/CloudTest.php:320

```