### PR TITLE
Provide PHP 8.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /clover.xml
 /coveralls-upload.json

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,14 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-escaper": "^2.7",
-        "laminas/laminas-stdlib": "^3.3",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "laminas/laminas-escaper": "^2.9",
+        "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-servicemanager": "^3.4.1",
-        "phpunit/phpunit": "^9.3"
+        "laminas/laminas-coding-standard": "~2.3",
+        "laminas/laminas-servicemanager": "^3.8",
+        "phpunit/phpunit": "^9.5.5"
     },
     "suggest": {
         "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
@@ -52,7 +51,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-tag": "^2.7.1"
+    "conflict": {
+        "zendframework/zend-tag": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,31 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57160f09d1680d98a2851ab5be607e57",
+    "content-hash": "b26c29329b22596f953acc1ce59548e7",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.7.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "5e04bc5ae5990b17159d79d331055e2c645e5cc5"
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/5e04bc5ae5990b17159d79d331055e2c645e5cc5",
-                "reference": "5e04bc5ae5990b17159d79d331055e2c645e5cc5",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-escaper": "^2.6.1"
+            "conflict": {
+                "zendframework/zend-escaper": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "phpunit/phpunit": "^9.3",
                 "psalm/plugin-phpunit": "^0.12.2",
                 "vimeo/psalm": "^3.16"
@@ -67,33 +66,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-11-17T21:26:43+00:00"
+            "time": "2021-09-02T17:10:53+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.3.1",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "d81c7ffe602ed0e6ecb18691019111c0f4bf1efe"
+                "reference": "db581851a092246ad99e12d4fddf105184924c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/d81c7ffe602ed0e6ecb18691019111c0f4bf1efe",
-                "reference": "d81c7ffe602ed0e6ecb18691019111c0f4bf1efe",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/db581851a092246ad99e12d4fddf105184924c71",
+                "reference": "db581851a092246ad99e12d4fddf105184924c71",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-stdlib": "^3.2.1"
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "phpbench/phpbench": "^0.17.1",
-                "phpunit/phpunit": "~9.3.7"
+                "phpunit/phpunit": "~9.3.7",
+                "psalm/plugin-phpunit": "^0.16.0",
+                "vimeo/psalm": "^4.7"
             },
             "type": "library",
             "autoload": {
@@ -125,67 +125,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-11-19T20:18:59+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
-                "squizlabs/php_codesniffer": "^3.5"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2020-09-14T14:23:00+00:00"
+            "time": "2021-11-10T11:33:52+00:00"
         }
     ],
     "packages-dev": [
@@ -224,6 +164,76 @@
             },
             "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -296,31 +306,36 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php": "^7.3 || ^8.0",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6",
+                "webimpress/coding-standard": "^1.2"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -334,50 +349,55 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-29T15:53:59+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.6.4",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828"
+                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/e52b985909e0940bf22d34f322eb3f48bbef6bd1",
+                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
                 "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "laminas/laminas-code": "<3.3.1",
-                "zendframework/zend-code": "<3.3.1"
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
             },
             "provide": {
                 "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
             },
-            "replace": {
-                "zendframework/zend-servicemanager": "^3.4.0"
-            },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-container-config-test": "^0.3",
-                "laminas/laminas-dependency-plugin": "^2.1",
-                "mikey179/vfsstream": "^1.6.8",
-                "ocramius/proxy-manager": "^2.2.3",
-                "phpbench/phpbench": "^1.0.0-alpha3",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4"
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -421,7 +441,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-03T08:44:41+00:00"
+            "time": "2021-09-18T20:19:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -483,16 +503,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.4",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -533,22 +553,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
             },
-            "time": "2020-12-20T10:01:03+00:00"
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -593,22 +613,22 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.4",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/e4782611070e50613683d2b9a57730e9a3ba5451",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -644,9 +664,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.0.4"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2020-12-13T23:18:30+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -703,16 +723,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -723,7 +743,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -753,22 +774,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
                 "shasum": ""
             },
             "require": {
@@ -776,7 +797,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -802,39 +824,39 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
             },
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2021-10-02T14:08:47+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -869,29 +891,78 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.5",
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
+            },
+            "time": "2021-09-16T20:46:02+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f301eb1453c9e7a1bc912ee8b0ea9db22c60223b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f301eb1453c9e7a1bc912ee8b0ea9db22c60223b",
+                "reference": "f301eb1453c9e7a1bc912ee8b0ea9db22c60223b",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.10.2",
+                "nikic/php-parser": "^4.13.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -940,7 +1011,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.9"
             },
             "funding": [
                 {
@@ -948,20 +1019,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:44:49+00:00"
+            "time": "2021-11-19T15:21:02+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
-                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
@@ -1000,7 +1071,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -1008,7 +1079,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:57:25+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -1193,16 +1264,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.2",
+            "version": "9.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4"
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f661659747f2f87f9e72095bb207bceb0f151cb4",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
                 "shasum": ""
             },
             "require": {
@@ -1214,11 +1285,11 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-code-coverage": "^9.2.7",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -1232,7 +1303,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -1280,7 +1351,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
             },
             "funding": [
                 {
@@ -1292,31 +1363,26 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-02T14:45:58+00:00"
+            "time": "2021-09-25T07:38:51+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.0.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -1329,7 +1395,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -1343,9 +1409,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1776,16 +1842,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -1834,14 +1900,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
             },
             "funding": [
                 {
@@ -1849,20 +1915,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -1905,7 +1971,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -1913,7 +1979,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -2204,16 +2270,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
@@ -2248,7 +2314,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -2256,7 +2322,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2312,64 +2378,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "7.0.16",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "14c324b2f2f0072933036c2f3abaeda16a56dcd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/14c324b2f2f0072933036c2f3abaeda16a56dcd3",
+                "reference": "14c324b2f2f0072933036c2f3abaeda16a56dcd3",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.0.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.0",
+                "php-parallel-lint/php-parallel-lint": "1.3.1",
+                "phpstan/phpstan": "0.12.99",
+                "phpstan/phpstan-deprecation-rules": "0.12.6",
+                "phpstan/phpstan-phpunit": "0.12.22",
+                "phpstan/phpstan-strict-rules": "0.12.11",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.5.10"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-22T06:56:51+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2382,7 +2482,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -2392,20 +2492,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -2417,7 +2517,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2455,7 +2555,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -2471,20 +2571,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -2513,7 +2613,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -2521,34 +2621,94 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.9.1",
+            "name": "webimpress/coding-standard",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/7a71421c7fc85827488f10c4c510fe80f94d1a74",
+                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-10-28T21:18:17+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -2572,9 +2732,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],
@@ -2583,8 +2743,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.4 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,8 +1,21 @@
-﻿<?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<?xml version="1.0"?>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    convertDeprecationsToExceptions="true"
+    colors="true">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="laminas-tag Test Suite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Cloud/Decorator/AbstractCloud.php
+++ b/src/Cloud/Decorator/AbstractCloud.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud\Decorator;
 

--- a/src/Cloud/Decorator/AbstractDecorator.php
+++ b/src/Cloud/Decorator/AbstractDecorator.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud\Decorator;
 
@@ -14,19 +10,22 @@ use Laminas\Tag\Cloud\Decorator\DecoratorInterface as Decorator;
 use Laminas\Tag\Exception;
 use Traversable;
 
+use function in_array;
+use function is_array;
+use function method_exists;
+use function preg_match;
+use function sprintf;
+use function strtolower;
+
 /**
  * Abstract class for decorators
  */
 abstract class AbstractDecorator implements Decorator
 {
-    /**
-     * @var string Encoding to use
-     */
+    /** @var string Encoding to use */
     protected $encoding = 'UTF-8';
 
-    /**
-     * @var Escaper
-     */
+    /** @var Escaper */
     protected $escaper;
 
     /**
@@ -89,7 +88,7 @@ abstract class AbstractDecorator implements Decorator
     /**
      * Set encoding
      *
-     * @param string
+     * @param string $value
      * @return HTMLCloud
      */
     public function setEncoding($value)

--- a/src/Cloud/Decorator/AbstractTag.php
+++ b/src/Cloud/Decorator/AbstractTag.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud\Decorator;
 

--- a/src/Cloud/Decorator/DecoratorInterface.php
+++ b/src/Cloud/Decorator/DecoratorInterface.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud\Decorator;
 

--- a/src/Cloud/Decorator/Exception/ExceptionInterface.php
+++ b/src/Cloud/Decorator/Exception/ExceptionInterface.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud\Decorator\Exception;
 

--- a/src/Cloud/Decorator/Exception/InvalidArgumentException.php
+++ b/src/Cloud/Decorator/Exception/InvalidArgumentException.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud\Decorator\Exception;
 

--- a/src/Cloud/Decorator/HtmlCloud.php
+++ b/src/Cloud/Decorator/HtmlCloud.php
@@ -1,12 +1,16 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud\Decorator;
+
+use function get_class;
+use function gettype;
+use function implode;
+use function is_array;
+use function is_object;
+use function sprintf;
 
 /**
  * Simple HTML decorator for clouds
@@ -33,7 +37,7 @@ class HtmlCloud extends AbstractCloud
      * Set the HTML tags surrounding all tags
      *
      * @param  array $htmlTags
-     * @return HTMLCloud
+     * @return HtmlCloud
      */
     public function setHTMLTags(array $htmlTags)
     {
@@ -54,8 +58,8 @@ class HtmlCloud extends AbstractCloud
     /**
      * Set the separator between the single tags
      *
-     * @param  string
-     * @return HTMLCloud
+     * @param  string $separator
+     * @return HtmlCloud
      */
     public function setSeparator($separator)
     {
@@ -85,7 +89,7 @@ class HtmlCloud extends AbstractCloud
         if (! is_array($tags)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'HtmlCloud::render() expects an array argument; received "%s"',
-                (is_object($tags) ? get_class($tags) : gettype($tags))
+                is_object($tags) ? get_class($tags) : gettype($tags)
             ));
         }
         $cloudHTML = implode($this->getSeparator(), $tags);

--- a/src/Cloud/Decorator/HtmlTag.php
+++ b/src/Cloud/Decorator/HtmlTag.php
@@ -1,15 +1,23 @@
-<?php
+<?php // phpcs:disable WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud\Decorator;
 
 use Laminas\Tag\Cloud\Decorator\Exception\InvalidArgumentException;
 use Laminas\Tag\ItemList;
+
+use function count;
+use function get_class;
+use function gettype;
+use function in_array;
+use function is_array;
+use function is_numeric;
+use function is_object;
+use function is_string;
+use function range;
+use function sprintf;
 
 /**
  * Simple HTML decorator for tags
@@ -22,7 +30,7 @@ class HtmlTag extends AbstractTag
      *
      * @var array
      */
-    protected $classList = null;
+    protected $classList;
 
     /**
      * Unit for the fontsize
@@ -44,7 +52,7 @@ class HtmlTag extends AbstractTag
      * @var array
      */
     protected $htmlTags = [
-        'li'
+        'li',
     ];
 
     /**
@@ -65,11 +73,11 @@ class HtmlTag extends AbstractTag
      * Set a list of classes to use instead of fontsizes
      *
      * @param  array $classList
-     * @throws InvalidArgumentException When the classlist is empty
-     * @throws InvalidArgumentException When the classlist contains an invalid classname
-     * @return HTMLTag
+     * @throws InvalidArgumentException When the classlist is empty.
+     * @throws InvalidArgumentException When the classlist contains an invalid classname.
+     * @return HtmlTag
      */
-    public function setClassList(array $classList = null)
+    public function setClassList(?array $classList = null)
     {
         if (is_array($classList)) {
             if (count($classList) === 0) {
@@ -103,8 +111,8 @@ class HtmlTag extends AbstractTag
      * Possible values are: em, ex, px, in, cm, mm, pt, pc and %
      *
      * @param  string $fontSizeUnit
-     * @throws InvalidArgumentException When an invalid fontsize unit is specified
-     * @return HTMLTag
+     * @throws InvalidArgumentException When an invalid fontsize unit is specified.
+     * @return HtmlTag
      */
     public function setFontSizeUnit($fontSizeUnit)
     {
@@ -126,12 +134,13 @@ class HtmlTag extends AbstractTag
     {
         return $this->fontSizeUnit;
     }
+
      /**
-     * Set the HTML tags surrounding the <a> element
-     *
-     * @param  array $htmlTags
-     * @return HTMLTag
-     */
+      * Set the HTML tags surrounding the <a> element
+      *
+      * @param  array $htmlTags
+      * @return HtmlTag
+      */
     public function setHTMLTags(array $htmlTags)
     {
         $this->htmlTags = $htmlTags;
@@ -152,8 +161,8 @@ class HtmlTag extends AbstractTag
      * Set maximum font size
      *
      * @param  int $maxFontSize
-     * @throws InvalidArgumentException When fontsize is not numeric
-     * @return HTMLTag
+     * @throws InvalidArgumentException When fontsize is not numeric.
+     * @return HtmlTag
      */
     public function setMaxFontSize($maxFontSize)
     {
@@ -180,8 +189,8 @@ class HtmlTag extends AbstractTag
      * Set minimum font size
      *
      * @param  int $minFontSize
-     * @throws InvalidArgumentException When fontsize is not numeric
-     * @return HTMLTag
+     * @throws InvalidArgumentException When fontsize is not numeric.
+     * @return HtmlTag
      */
     public function setMinFontSize($minFontSize)
     {
@@ -216,7 +225,7 @@ class HtmlTag extends AbstractTag
         if (! $tags instanceof ItemList) {
             throw new InvalidArgumentException(sprintf(
                 'HtmlTag::render() expects a Laminas\Tag\ItemList argument; received "%s"',
-                (is_object($tags) ? get_class($tags) : gettype($tags))
+                is_object($tags) ? get_class($tags) : gettype($tags)
             ));
         }
         if (null === ($weightValues = $this->getClassList())) {
@@ -236,14 +245,14 @@ class HtmlTag extends AbstractTag
                     $this->getFontSizeUnit()
                 );
             } else {
-                $attribute = sprintf('class="%s"', $escaper->escapeHtmlAttr($tag->getParam('weightValue')));
+                $attribute = sprintf('class="%s"', $escaper->escapeHtmlAttr($tag->getParam('weightValue' ?? '')));
             }
 
             $tagHTML  = sprintf(
                 '<a href="%s" %s>%s</a>',
-                $escaper->escapeHtml($tag->getParam('url')),
+                $escaper->escapeHtml($tag->getParam('url') ?? ''),
                 $attribute,
-                $escaper->escapeHtml($tag->getTitle())
+                $escaper->escapeHtml($tag->getTitle() ?? '')
             );
             $tagHTML  = $this->wrapTag($tagHTML);
             $result[] = $tagHTML;

--- a/src/Cloud/DecoratorPluginManager.php
+++ b/src/Cloud/DecoratorPluginManager.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Cloud;
 
@@ -12,6 +8,13 @@ use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use RuntimeException;
+use Zend\Tag\Cloud\Decorator\HtmlCloud;
+use Zend\Tag\Cloud\Decorator\HtmlTag;
+
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 /**
  * Plugin manager implementation for decorators.
@@ -22,6 +25,7 @@ use RuntimeException;
  */
 class DecoratorPluginManager extends AbstractPluginManager
 {
+    /** @var array<string, string> */
     protected $aliases = [
         'htmlcloud' => Decorator\HtmlCloud::class,
         'htmlCloud' => Decorator\HtmlCloud::class,
@@ -35,14 +39,15 @@ class DecoratorPluginManager extends AbstractPluginManager
         'Tag'       => Decorator\HtmlTag::class,
 
         // Legacy Zend Framework aliases
-        \Zend\Tag\Cloud\Decorator\HtmlCloud::class => Decorator\HtmlCloud::class,
-        \Zend\Tag\Cloud\Decorator\HtmlTag::class => Decorator\HtmlTag::class,
+        HtmlCloud::class => Decorator\HtmlCloud::class,
+        HtmlTag::class   => Decorator\HtmlTag::class,
 
         // v2 normalized FQCNs
         'zendtagclouddecoratorhtmlcloud' => Decorator\HtmlCloud::class,
-        'zendtagclouddecoratorhtmltag' => Decorator\HtmlTag::class,
+        'zendtagclouddecoratorhtmltag'   => Decorator\HtmlTag::class,
     ];
 
+    /** @var array<string, string> */
     protected $factories = [
         Decorator\HtmlCloud::class => InvokableFactory::class,
         Decorator\HtmlTag::class   => InvokableFactory::class,
@@ -50,9 +55,10 @@ class DecoratorPluginManager extends AbstractPluginManager
         // alias is used to look up the factory, while the non-normalized
         // resolved alias is used as the requested name passed to the factory.
         'laminastagclouddecoratorhtmlcloud' => InvokableFactory::class,
-        'laminastagclouddecoratorhtmltag'   => InvokableFactory::class
+        'laminastagclouddecoratorhtmltag'   => InvokableFactory::class,
     ];
 
+    /** @var string */
     protected $instanceOf = Decorator\DecoratorInterface::class;
 
     /**
@@ -68,9 +74,9 @@ class DecoratorPluginManager extends AbstractPluginManager
         if (! $instance instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(
                 '%s can only create instances of %s; %s is invalid',
-                get_class($this),
+                static::class,
                 $this->instanceOf,
-                (is_object($instance) ? get_class($instance) : gettype($instance))
+                is_object($instance) ? get_class($instance) : gettype($instance)
             ));
         }
     }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Exception;
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Exception;
 

--- a/src/Exception/InvalidAttributeNameException.php
+++ b/src/Exception/InvalidAttributeNameException.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Exception;
 

--- a/src/Exception/InvalidElementNameException.php
+++ b/src/Exception/InvalidElementNameException.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Exception;
 

--- a/src/Exception/OutOfBoundsException.php
+++ b/src/Exception/OutOfBoundsException.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag\Exception;
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -1,15 +1,19 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag;
 
 use Laminas\Stdlib\ArrayUtils;
+use Laminas\Tag\Exception\InvalidArgumentException;
 use Traversable;
+
+use function in_array;
+use function is_array;
+use function is_numeric;
+use function is_string;
+use function method_exists;
+use function strtolower;
 
 class Item implements TaggableInterface
 {
@@ -18,14 +22,14 @@ class Item implements TaggableInterface
      *
      * @var string
      */
-    protected $title = null;
+    protected $title;
 
     /**
      * Weight of the tag
      *
      * @var float
      */
-    protected $weight = null;
+    protected $weight;
 
     /**
      * Custom parameters
@@ -41,16 +45,16 @@ class Item implements TaggableInterface
      */
     protected $skipOptions = [
         'options',
-        'param'
+        'param',
     ];
 
     /**
      * Create a new tag according to the options
      *
      * @param  array|Traversable $options
-     * @throws \Laminas\Tag\Exception\InvalidArgumentException When invalid options are provided
-     * @throws \Laminas\Tag\Exception\InvalidArgumentException When title was not set
-     * @throws \Laminas\Tag\Exception\InvalidArgumentException When weight was not set
+     * @throws InvalidArgumentException When invalid options are provided.
+     * @throws InvalidArgumentException When title was not set.
+     * @throws InvalidArgumentException When weight was not set.
      */
     public function __construct($options)
     {
@@ -59,17 +63,17 @@ class Item implements TaggableInterface
         }
 
         if (! is_array($options)) {
-            throw new Exception\InvalidArgumentException('Invalid options provided to constructor');
+            throw new InvalidArgumentException('Invalid options provided to constructor');
         }
 
         $this->setOptions($options);
 
         if ($this->title === null) {
-            throw new Exception\InvalidArgumentException('Title was not set');
+            throw new InvalidArgumentException('Title was not set');
         }
 
         if ($this->weight === null) {
-            throw new Exception\InvalidArgumentException('Weight was not set');
+            throw new InvalidArgumentException('Weight was not set');
         }
     }
 
@@ -77,7 +81,7 @@ class Item implements TaggableInterface
      * Set options of the tag
      *
      * @param  array $options
-     * @return \Laminas\Tag\Item
+     * @return Item
      */
     public function setOptions(array $options)
     {
@@ -109,13 +113,13 @@ class Item implements TaggableInterface
      * Set the title
      *
      * @param  string $title
-     * @throws \Laminas\Tag\Exception\InvalidArgumentException When title is no string
-     * @return \Laminas\Tag\Item
+     * @throws InvalidArgumentException When title is no string.
+     * @return Item
      */
     public function setTitle($title)
     {
         if (! is_string($title)) {
-            throw new Exception\InvalidArgumentException('Title must be a string');
+            throw new InvalidArgumentException('Title must be a string');
         }
 
         $this->title = (string) $title;
@@ -136,13 +140,13 @@ class Item implements TaggableInterface
      * Set the weight
      *
      * @param  float $weight
-     * @throws \Laminas\Tag\Exception\InvalidArgumentException When weight is not numeric
-     * @return \Laminas\Tag\Item
+     * @throws InvalidArgumentException When weight is not numeric.
+     * @return Item
      */
     public function setWeight($weight)
     {
         if (! is_numeric($weight)) {
-            throw new Exception\InvalidArgumentException('Weight must be numeric');
+            throw new InvalidArgumentException('Weight must be numeric');
         }
 
         $this->weight = (float) $weight;
@@ -153,7 +157,7 @@ class Item implements TaggableInterface
      * Set multiple params at once
      *
      * @param  array $params
-     * @return \Laminas\Tag\Item
+     * @return Item
      */
     public function setParams(array $params)
     {
@@ -169,7 +173,7 @@ class Item implements TaggableInterface
      *
      * @param  string $name
      * @param  mixed  $value
-     * @return \Laminas\Tag\Item
+     * @return Item
      */
     public function setParam($name, $value)
     {
@@ -188,6 +192,6 @@ class Item implements TaggableInterface
         if (isset($this->params[$name])) {
             return $this->params[$name];
         }
-        return;
+        return null;
     }
 }

--- a/src/ItemList.php
+++ b/src/ItemList.php
@@ -8,6 +8,7 @@ use ArrayAccess;
 use Countable;
 use Laminas\Tag\Exception\InvalidArgumentException;
 use Laminas\Tag\Exception\OutOfBoundsException;
+use ReturnTypeWillChange;
 use SeekableIterator;
 
 use function array_key_exists;
@@ -36,6 +37,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);
@@ -108,6 +110,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      * @throws OutOfBoundsException When the seek position is invalid.
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function seek($index)
     {
         $this->rewind();
@@ -128,6 +131,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
@@ -138,6 +142,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->items);
@@ -148,6 +153,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);
@@ -158,6 +164,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->current() !== false;
@@ -168,6 +175,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->items);
@@ -179,6 +187,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->items);
@@ -190,6 +199,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return TaggableInterface
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->items[$offset];
@@ -203,6 +213,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      * @throws OutOfBoundsException When item does not implement Laminas\Tag\TaggableInterface.
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $item)
     {
         // We need to make that check here, as the method signature must be
@@ -224,6 +235,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->items[$offset]);

--- a/src/ItemList.php
+++ b/src/ItemList.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag;
 
@@ -13,6 +9,18 @@ use Countable;
 use Laminas\Tag\Exception\InvalidArgumentException;
 use Laminas\Tag\Exception\OutOfBoundsException;
 use SeekableIterator;
+
+use function array_key_exists;
+use function array_values;
+use function count;
+use function current;
+use function floor;
+use function key;
+use function log;
+use function max;
+use function min;
+use function next;
+use function reset;
 
 class ItemList implements Countable, SeekableIterator, ArrayAccess
 {
@@ -37,7 +45,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      * Spread values in the items relative to their weight
      *
      * @param  array $values
-     * @throws InvalidArgumentException When value list is empty
+     * @throws InvalidArgumentException When value list is empty.
      * @return void
      */
     public function spreadWeightValues(array $values)
@@ -97,7 +105,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      * Seek to an absolute position
      *
      * @param  int $index
-     * @throws OutOfBoundsException When the seek position is invalid
+     * @throws OutOfBoundsException When the seek position is invalid.
      * @return void
      */
     public function seek($index)
@@ -152,7 +160,7 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      */
     public function valid()
     {
-        return ($this->current() !== false);
+        return $this->current() !== false;
     }
 
     /**
@@ -192,14 +200,14 @@ class ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @param  mixed          $offset
      * @param  TaggableInterface $item
-     * @throws OutOfBoundsException When item does not implement Laminas\Tag\TaggableInterface
+     * @throws OutOfBoundsException When item does not implement Laminas\Tag\TaggableInterface.
      * @return void
      */
     public function offsetSet($offset, $item)
     {
         // We need to make that check here, as the method signature must be
         // compatible with ArrayAccess::offsetSet()
-        if (! ($item instanceof TaggableInterface)) {
+        if (! $item instanceof TaggableInterface) {
             throw new OutOfBoundsException('Item must implement Laminas\Tag\TaggableInterface');
         }
 

--- a/src/TaggableInterface.php
+++ b/src/TaggableInterface.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace Laminas\Tag;
 

--- a/test/Cloud/CloudTest.php
+++ b/test/Cloud/CloudTest.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag\Cloud;
 
@@ -12,9 +8,11 @@ use ArrayObject;
 use Laminas\ServiceManager\Config as SMConfig;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Tag;
+use Laminas\Tag\Cloud;
 use Laminas\Tag\Cloud\Decorator\HtmlCloud;
 use Laminas\Tag\Cloud\Decorator\HtmlTag;
 use Laminas\Tag\Cloud\DecoratorPluginManager;
+use Laminas\Tag\Exception\InvalidArgumentException;
 use Laminas\Tag\ItemList;
 use LaminasTest\Tag\Cloud\TestAsset\CloudDummy;
 use LaminasTest\Tag\Cloud\TestAsset\TagDummy;
@@ -49,7 +47,7 @@ class CloudTest extends TestCase
         $cloud = $this->getCloud();
         $this->assertInstanceOf(HtmlCloud::class, $cloud->getCloudDecorator());
 
-        $cloud->setCloudDecorator(new TestAsset\CloudDummy());
+        $cloud->setCloudDecorator(new CloudDummy());
         $this->assertInstanceOf(CloudDummy::class, $cloud->getCloudDecorator());
     }
 
@@ -57,7 +55,7 @@ class CloudTest extends TestCase
     {
         $cloud = $this->getCloud();
 
-        $this->expectException('Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('DecoratorInterface');
         $cloud->setCloudDecorator(new stdClass());
     }
@@ -70,7 +68,7 @@ class CloudTest extends TestCase
             'options'   => ['foo' => 'bar'],
         ]);
 
-        $this->assertInstanceOf('LaminasTest\Tag\Cloud\TestAsset\TagDummy', $cloud->getTagDecorator());
+        $this->assertInstanceOf(TagDummy::class, $cloud->getTagDecorator());
         $this->assertEquals('bar', $cloud->getTagDecorator()->getFoo());
     }
 
@@ -79,7 +77,7 @@ class CloudTest extends TestCase
         $cloud = $this->getCloud();
         $this->assertInstanceOf(HtmlTag::class, $cloud->getTagDecorator());
 
-        $cloud->setTagDecorator(new TestAsset\TagDummy());
+        $cloud->setTagDecorator(new TagDummy());
         $this->assertInstanceOf(TagDummy::class, $cloud->getTagDecorator());
     }
 
@@ -87,7 +85,7 @@ class CloudTest extends TestCase
     {
         $cloud = $this->getCloud();
 
-        $this->expectException('Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('DecoratorInterface');
         $cloud->setTagDecorator(new stdClass());
     }
@@ -96,7 +94,7 @@ class CloudTest extends TestCase
     {
         $decorators = new DecoratorPluginManager(new ServiceManager());
 
-        $cloud = $this->getCloud([], null);
+        $cloud = $this->getCloud([], false);
         $cloud->setDecoratorPluginManager($decorators);
 
         $this->assertSame($decorators, $cloud->getDecoratorPluginManager());
@@ -105,7 +103,7 @@ class CloudTest extends TestCase
     public function testSetDecoratorPluginManagerViaOptions()
     {
         $decorators = new DecoratorPluginManager(new ServiceManager());
-        $cloud      = $this->getCloud(['decoratorPluginManager' => $decorators], null);
+        $cloud      = $this->getCloud(['decoratorPluginManager' => $decorators], false);
 
         $this->assertSame($decorators, $cloud->getDecoratorPluginManager());
     }
@@ -140,7 +138,7 @@ class CloudTest extends TestCase
     {
         $cloud = $this->getCloud();
 
-        $this->expectException('Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('TaggableInterface');
         $cloud->appendTag('foo');
     }
@@ -158,7 +156,7 @@ class CloudTest extends TestCase
             [
                 'title'  => 'bar',
                 'weight' => 2,
-            ]
+            ],
         ]);
 
         $this->assertEquals('foo', $list[0]->getTitle());
@@ -209,7 +207,7 @@ class CloudTest extends TestCase
     {
         $cloud = $this->getCloud();
 
-        $this->expectException('Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('TaggableInterface');
         $cloud->setTags(['foo']);
     }
@@ -317,10 +315,10 @@ class CloudTest extends TestCase
             . '<li><a href="" style="font-size: 10px;">foo</a></li> '
             . '<li><a href="" style="font-size: 20px;">bar</a></li>'
             . '</ul>';
-        $this->assertEquals($expected, (string)$cloud);
+        $this->assertEquals($expected, (string) $cloud);
     }
 
-    protected function getCloud($options = null, $setDecoratorPluginManager = true)
+    protected function getCloud(?iterable $options = null, bool $setDecoratorPluginManager = true): Cloud
     {
         $cloud = new Tag\Cloud($options);
 
@@ -335,10 +333,10 @@ class CloudTest extends TestCase
             ]);
             */
             $smConfig = new SMConfig([
-              'invokables' => [
-                  'CloudDummy' => CloudDummy::class,
-                  'TagDummy'   => TagDummy::class
-              ]
+                'invokables' => [
+                    'CloudDummy' => CloudDummy::class,
+                    'TagDummy'   => TagDummy::class,
+                ],
             ]);
             $smConfig->configureServiceManager($decorators);
         }

--- a/test/Cloud/Decorator/DecoratorPluginManagerCompatibilityTest.php
+++ b/test/Cloud/Decorator/DecoratorPluginManagerCompatibilityTest.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\ServiceManager;
 
@@ -13,6 +9,7 @@ use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use Laminas\Tag\Cloud\Decorator\DecoratorInterface;
 use Laminas\Tag\Cloud\DecoratorPluginManager;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * Example test of using CommonPluginManagerTrait
@@ -21,16 +18,19 @@ class DecoratorPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
+    /** @return DecoratorPluginManager */
     protected function getPluginManager()
     {
         return new DecoratorPluginManager(new ServiceManager());
     }
 
+    /** @return string */
     protected function getV2InvalidPluginException()
     {
-        return \RuntimeException::class;
+        return RuntimeException::class;
     }
 
+    /** @return string */
     protected function getInstanceOf()
     {
         return DecoratorInterface::class;

--- a/test/Cloud/Decorator/HtmlCloudTest.php
+++ b/test/Cloud/Decorator/HtmlCloudTest.php
@@ -1,15 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag\Cloud\Decorator;
 
 use ArrayObject;
 use Laminas\Tag\Cloud\Decorator;
+use Laminas\Tag\Exception\InvalidAttributeNameException;
+use Laminas\Tag\Exception\InvalidElementNameException;
 use PHPUnit\Framework\TestCase;
 
 class HtmlCloudTest extends TestCase
@@ -22,8 +20,8 @@ class HtmlCloudTest extends TestCase
             '<ul class="laminas-tag-cloud">foo bar</ul>',
             $decorator->render(
                 [
-                     'foo',
-                     'bar'
+                    'foo',
+                    'bar',
                 ]
             )
         );
@@ -34,8 +32,8 @@ class HtmlCloudTest extends TestCase
         $decorator = new Decorator\HtmlCloud();
         $decorator->setHtmlTags(
             [
-                 'span',
-                 'div' => ['id' => 'tag-cloud']
+                'span',
+                'div' => ['id' => 'tag-cloud'],
             ]
         );
 
@@ -43,8 +41,8 @@ class HtmlCloudTest extends TestCase
             '<div id="tag-cloud"><span>foo bar</span></div>',
             $decorator->render(
                 [
-                     'foo',
-                     'bar'
+                    'foo',
+                    'bar',
                 ]
             )
         );
@@ -59,8 +57,8 @@ class HtmlCloudTest extends TestCase
             '<ul class="laminas-tag-cloud">foo-bar</ul>',
             $decorator->render(
                 [
-                     'foo',
-                     'bar'
+                    'foo',
+                    'bar',
                 ]
             )
         );
@@ -77,7 +75,7 @@ class HtmlCloudTest extends TestCase
             '<div>foo bar</div>',
             $decorator->render([
                 'foo',
-                'bar'
+                'bar',
             ])
         );
     }
@@ -91,14 +89,14 @@ class HtmlCloudTest extends TestCase
     {
         $decorator = new Decorator\HtmlCloud(new ArrayObject([
             'htmlTags'  => ['div'],
-            'separator' => ' '
+            'separator' => ' ',
         ]));
 
         $this->assertEquals(
             '<div>foo bar</div>',
             $decorator->render([
                 'foo',
-                'bar'
+                'bar',
             ])
         );
     }
@@ -108,14 +106,14 @@ class HtmlCloudTest extends TestCase
         $decorator = new Decorator\HtmlCloud();
         $decorator->setOptions([
             'htmlTags'  => ['div'],
-            'separator' => ' '
+            'separator' => ' ',
         ]);
 
         $this->assertEquals(
             '<div>foo bar</div>',
             $decorator->render([
                 'foo',
-                'bar'
+                'bar',
             ])
         );
     }
@@ -126,7 +124,8 @@ class HtmlCloudTest extends TestCase
         // In case would fail due to an error
     }
 
-    public function invalidHtmlTagProvider()
+    /** @psalm-return array<array-key, array{0: string[]|array<string, array>}> */
+    public function invalidHtmlTagProvider(): array
     {
         return [
             [['_foo']],
@@ -136,7 +135,7 @@ class HtmlCloudTest extends TestCase
             [
                 [
                     '_foo' => [],
-                ]
+                ],
             ],
         ];
     }
@@ -144,15 +143,16 @@ class HtmlCloudTest extends TestCase
     /**
      * @dataProvider invalidHtmlTagProvider
      */
-    public function testInvalidHtmlTagsRaiseAnException($tags)
+    public function testInvalidHtmlTagsRaiseAnException(array $tags)
     {
         $decorator = new Decorator\HtmlCloud();
         $decorator->setHTMLTags($tags);
-        $this->expectException('Laminas\Tag\Exception\InvalidElementNameException');
+        $this->expectException(InvalidElementNameException::class);
         $decorator->render([]);
     }
 
-    public function invalidAttributeProvider()
+    /** @psalm-return array<array-key, array{0: array<string, map>}> */
+    public function invalidAttributeProvider(): array
     {
         return [
             [
@@ -160,21 +160,21 @@ class HtmlCloudTest extends TestCase
                     'foo' => [
                         '&bar' => 'baz',
                     ],
-                ]
+                ],
             ],
             [
                 [
                     'foo' => [
                         ':bar&baz' => 'bat',
                     ],
-                ]
+                ],
             ],
             [
                 [
                     'foo' => [
                         'bar/baz' => 'bat',
                     ],
-                ]
+                ],
             ],
         ];
     }
@@ -182,11 +182,11 @@ class HtmlCloudTest extends TestCase
     /**
      * @dataProvider invalidAttributeProvider
      */
-    public function testInvalidAttributeNamesRaiseAnException($tags)
+    public function testInvalidAttributeNamesRaiseAnException(array $tags)
     {
         $decorator = new Decorator\HtmlCloud();
         $decorator->setHTMLTags($tags);
-        $this->expectException('Laminas\Tag\Exception\InvalidAttributeNameException');
+        $this->expectException(InvalidAttributeNameException::class);
         $decorator->render([]);
     }
 }

--- a/test/Cloud/Decorator/HtmlTagTest.php
+++ b/test/Cloud/Decorator/HtmlTagTest.php
@@ -1,16 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag\Cloud\Decorator;
 
 use ArrayObject;
 use Laminas\Tag;
 use Laminas\Tag\Cloud\Decorator;
+use Laminas\Tag\Cloud\Decorator\Exception\InvalidArgumentException;
+use Laminas\Tag\Exception\InvalidAttributeNameException;
+use Laminas\Tag\Exception\InvalidElementNameException;
 use PHPUnit\Framework\TestCase;
 
 class HtmlTagTest extends TestCase
@@ -18,9 +17,11 @@ class HtmlTagTest extends TestCase
     public function testDefaultOutput()
     {
         $decorator = new Decorator\HtmlTag();
-        $expected  = ['<li><a href="http://first" style="font-size: 10px;">foo</a></li>',
-                           '<li><a href="http://second" style="font-size: 13px;">bar</a></li>',
-                           '<li><a href="http://third" style="font-size: 20px;">baz</a></li>'];
+        $expected  = [
+            '<li><a href="http://first" style="font-size: 10px;">foo</a></li>',
+            '<li><a href="http://second" style="font-size: 13px;">bar</a></li>',
+            '<li><a href="http://third" style="font-size: 20px;">baz</a></li>',
+        ];
 
         $this->assertEquals($decorator->render($this->_getTagList()), $expected);
     }
@@ -29,9 +30,11 @@ class HtmlTagTest extends TestCase
     {
         $decorator = new Decorator\HtmlTag();
         $decorator->setHtmlTags(['span' => ['class' => 'tag'], 'li']);
-        $expected  = ['<li><span class="tag"><a href="http://first" style="font-size: 10px;">foo</a></span></li>',
-                           '<li><span class="tag"><a href="http://second" style="font-size: 13px;">bar</a></span></li>',
-                           '<li><span class="tag"><a href="http://third" style="font-size: 20px;">baz</a></span></li>'];
+        $expected = [
+            '<li><span class="tag"><a href="http://first" style="font-size: 10px;">foo</a></span></li>',
+            '<li><span class="tag"><a href="http://second" style="font-size: 13px;">bar</a></span></li>',
+            '<li><span class="tag"><a href="http://third" style="font-size: 20px;">baz</a></span></li>',
+        ];
 
         $this->assertEquals($decorator->render($this->_getTagList()), $expected);
     }
@@ -43,9 +46,11 @@ class HtmlTagTest extends TestCase
                   ->setMinFontSize(5)
                   ->setMaxFontSize(50);
 
-        $expected  = ['<li><a href="http://first" style="font-size: 5pt;">foo</a></li>',
-                           '<li><a href="http://second" style="font-size: 15pt;">bar</a></li>',
-                           '<li><a href="http://third" style="font-size: 50pt;">baz</a></li>'];
+        $expected = [
+            '<li><a href="http://first" style="font-size: 5pt;">foo</a></li>',
+            '<li><a href="http://second" style="font-size: 15pt;">bar</a></li>',
+            '<li><a href="http://third" style="font-size: 50pt;">baz</a></li>',
+        ];
 
         $this->assertEquals($decorator->render($this->_getTagList()), $expected);
     }
@@ -55,9 +60,11 @@ class HtmlTagTest extends TestCase
         $decorator = new Decorator\HtmlTag();
         $decorator->setClassList(['small', 'medium', 'large']);
 
-        $expected  = ['<li><a href="http://first" class="small">foo</a></li>',
-                           '<li><a href="http://second" class="medium">bar</a></li>',
-                           '<li><a href="http://third" class="large">baz</a></li>'];
+        $expected = [
+            '<li><a href="http://first" class="small">foo</a></li>',
+            '<li><a href="http://second" class="medium">bar</a></li>',
+            '<li><a href="http://third" class="large">baz</a></li>',
+        ];
 
         $this->assertEquals($decorator->render($this->_getTagList()), $expected);
     }
@@ -66,7 +73,7 @@ class HtmlTagTest extends TestCase
     {
         $decorator = new Decorator\HtmlTag();
 
-        $this->expectException('Laminas\Tag\Cloud\Decorator\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Classlist is empty');
         $decorator->setClassList([]);
     }
@@ -75,7 +82,7 @@ class HtmlTagTest extends TestCase
     {
         $decorator = new Decorator\HtmlTag();
 
-        $this->expectException('Laminas\Tag\Cloud\Decorator\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Classlist contains an invalid classname');
         $decorator->setClassList([[]]);
     }
@@ -84,7 +91,7 @@ class HtmlTagTest extends TestCase
     {
         $decorator = new Decorator\HtmlTag();
 
-        $this->expectException('Laminas\Tag\Cloud\Decorator\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid fontsize unit specified');
         $decorator->setFontSizeUnit('foo');
     }
@@ -93,7 +100,7 @@ class HtmlTagTest extends TestCase
     {
         $decorator = new Decorator\HtmlTag();
 
-        $this->expectException('Laminas\Tag\Cloud\Decorator\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Fontsize must be numeric');
         $decorator->setMinFontSize('foo');
     }
@@ -102,7 +109,7 @@ class HtmlTagTest extends TestCase
     {
         $decorator = new Decorator\HtmlTag();
 
-        $this->expectException('Laminas\Tag\Cloud\Decorator\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Fontsize must be numeric');
         $decorator->setMaxFontSize('foo');
     }
@@ -124,8 +131,8 @@ class HtmlTagTest extends TestCase
     public function testConstructorWithConfig()
     {
         $decorator = new Decorator\HtmlTag(new ArrayObject([
-            'minFontSize' => 5,
-            'maxFontSize' => 10,
+            'minFontSize'  => 5,
+            'maxFontSize'  => 10,
             'fontSizeUnit' => 'pt',
         ]));
 
@@ -162,11 +169,11 @@ class HtmlTagTest extends TestCase
         return $list;
     }
 
-    public function getTags()
+    public function getTags(): Tag\ItemList
     {
-        $tags = new Tag\ItemList();
+        $tags   = new Tag\ItemList();
         $tags[] = new Tag\Item([
-            'title' => 'tag',
+            'title'  => 'tag',
             'weight' => 1,
             'params' => [
                 'url' => 'http://testing',
@@ -175,59 +182,69 @@ class HtmlTagTest extends TestCase
         return $tags;
     }
 
-    public function invalidHtmlElementProvider()
+    /** @psalm-return array<array-key, array{0: list<string>|array<string, array>}> */
+    public function invalidHtmlElementProvider(): array
     {
         return [
             [['_foo']],
             [['&foo']],
             [[' foo']],
             [[' foo']],
-            [[
-                '_foo' => [],
-            ]],
+            [
+                [
+                    '_foo' => [],
+                ],
+            ],
         ];
     }
 
     /**
      * @dataProvider invalidHtmlElementProvider
      */
-    public function testInvalidElementNamesRaiseAnException($tags)
+    public function testInvalidElementNamesRaiseAnException(array $tags)
     {
         $decorator = new Decorator\HtmlTag();
         $decorator->setHTMLTags($tags);
-        $this->expectException('Laminas\Tag\Exception\InvalidElementNameException');
+        $this->expectException(InvalidElementNameException::class);
         $decorator->render($this->getTags());
     }
 
-    public function invalidAttributeProvider()
+    /** @psalm-return array<array-key, array{0: array<string, map>}> */
+    public function invalidAttributeProvider(): array
     {
         return [
-            [[
-                'foo' => [
-                    '&bar' => 'baz',
+            [
+                [
+                    'foo' => [
+                        '&bar' => 'baz',
+                    ],
                 ],
-            ]],
-            [[
-                'foo' => [
-                    ':bar&baz' => 'bat',
+            ],
+            [
+                [
+                    'foo' => [
+                        ':bar&baz' => 'bat',
+                    ],
                 ],
-            ]],
-            [[
-                'foo' => [
-                    'bar/baz' => 'bat',
+            ],
+            [
+                [
+                    'foo' => [
+                        'bar/baz' => 'bat',
+                    ],
                 ],
-            ]],
+            ],
         ];
     }
 
     /**
      * @dataProvider invalidAttributeProvider
      */
-    public function testInvalidAttributesRaiseAnException($tags)
+    public function testInvalidAttributesRaiseAnException(array $tags)
     {
         $decorator = new Decorator\HtmlTag();
         $decorator->setHTMLTags($tags);
-        $this->expectException('Laminas\Tag\Exception\InvalidAttributeNameException');
+        $this->expectException(InvalidAttributeNameException::class);
         $decorator->render($this->getTags());
     }
 }

--- a/test/Cloud/TestAsset/CloudDummy.php
+++ b/test/Cloud/TestAsset/CloudDummy.php
@@ -1,24 +1,23 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag\Cloud\TestAsset;
 
-class CloudDummy extends \Laminas\Tag\Cloud\Decorator\HtmlCloud
-{
-    // @codingStandardsIgnoreStart
-    protected $_foo;
-    // @codingStandardsIgnoreEnd
+use Laminas\Tag\Cloud\Decorator\HtmlCloud;
 
+class CloudDummy extends HtmlCloud
+{
+    // phpcs:ignore
+    protected $_foo;
+
+    /** @param mixed $value */
     public function setFoo($value)
     {
         $this->_foo = $value;
     }
 
+    /** @return mixed */
     public function getFoo()
     {
         return $this->_foo;

--- a/test/Cloud/TestAsset/CloudDummy1.php
+++ b/test/Cloud/TestAsset/CloudDummy1.php
@@ -1,24 +1,23 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag\Cloud\TestAsset;
 
-class CloudDummy1 extends \Laminas\Tag\Cloud\Decorator\HtmlCloud
-{
-    // @codingStandardsIgnoreStart
-    protected $_foo;
-    // @codingStandardsIgnoreEnd
+use Laminas\Tag\Cloud\Decorator\HtmlCloud;
 
+class CloudDummy1 extends HtmlCloud
+{
+    // phpcs:ignore
+    protected $_foo;
+
+    /** @param mixed $value */
     public function setFoo($value)
     {
         $this->_foo = $value;
     }
 
+    /** @return mixed */
     public function getFoo()
     {
         return $this->_foo;

--- a/test/Cloud/TestAsset/CloudDummy2.php
+++ b/test/Cloud/TestAsset/CloudDummy2.php
@@ -1,24 +1,23 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag\Cloud\TestAsset;
 
-class CloudDummy2 extends \Laminas\Tag\Cloud\Decorator\HtmlCloud
-{
-    // @codingStandardsIgnoreStart
-    protected $_foo;
-    // @codingStandardsIgnoreEnd
+use Laminas\Tag\Cloud\Decorator\HtmlCloud;
 
+class CloudDummy2 extends HtmlCloud
+{
+    // phpcs:ignore
+    protected $_foo;
+
+    /** @param mixed $value */
     public function setFoo($value)
     {
         $this->_foo = $value;
     }
 
+    /** @return mixed */
     public function getFoo()
     {
         return $this->_foo;

--- a/test/Cloud/TestAsset/ItemListDummy.php
+++ b/test/Cloud/TestAsset/ItemListDummy.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag\Cloud\TestAsset;
 

--- a/test/Cloud/TestAsset/TagDummy.php
+++ b/test/Cloud/TestAsset/TagDummy.php
@@ -1,24 +1,23 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag\Cloud\TestAsset;
 
-class TagDummy extends \Laminas\Tag\Cloud\Decorator\HtmlTag
-{
-    // @codingStandardsIgnoreStart
-    protected $_foo;
-    // @codingStandardsIgnoreEnd
+use Laminas\Tag\Cloud\Decorator\HtmlTag;
 
+class TagDummy extends HtmlTag
+{
+    // phpcs:ignore
+    protected $_foo;
+
+    /** @param mixed $value */
     public function setFoo($value)
     {
         $this->_foo = $value;
     }
 
+    /** @return mixed */
     public function getFoo()
     {
         return $this->_foo;

--- a/test/ItemListTest.php
+++ b/test/ItemListTest.php
@@ -1,15 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag;
 
 use Laminas\Tag;
+use Laminas\Tag\Exception\InvalidArgumentException;
+use Laminas\Tag\Exception\OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
+
+use function count;
 
 class ItemListTest extends TestCase
 {
@@ -58,7 +58,7 @@ class ItemListTest extends TestCase
         }
         $list->seek(2);
 
-        $this->expectException('Laminas\Tag\Exception\OutOfBoundsException');
+        $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('Invalid seek position');
         $list->seek(3);
     }
@@ -67,7 +67,7 @@ class ItemListTest extends TestCase
     {
         $list = new Tag\ItemList();
 
-        $this->expectException('\Laminas\Tag\Exception\OutOfBoundsException');
+        $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('Item must implement Laminas\Tag\TaggableInterface');
         $list[] = 'test';
     }
@@ -116,7 +116,7 @@ class ItemListTest extends TestCase
     {
         $list = new Tag\ItemList();
 
-        $this->expectException('Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Value list may not be empty');
         $list->spreadWeightValues([]);
     }

--- a/test/ItemTest.php
+++ b/test/ItemTest.php
@@ -1,15 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-tag for the canonical source repository
- * @copyright https://github.com/laminas/laminas-tag/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-tag/blob/master/LICENSE.md New BSD License
- */
+declare(strict_types=1);
 
 namespace LaminasTest\Tag;
 
 use ArrayObject;
 use Laminas\Tag;
+use Laminas\Tag\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ItemTest extends TestCase
@@ -17,11 +14,11 @@ class ItemTest extends TestCase
     public function testConstructor()
     {
         $tag = new Tag\Item([
-            'title' => 'foo',
+            'title'  => 'foo',
             'weight' => 10,
             'params' => [
-                'bar' => 'baz'
-            ]
+                'bar' => 'baz',
+            ],
         ]);
 
         $this->assertEquals('foo', $tag->getTitle());
@@ -33,11 +30,11 @@ class ItemTest extends TestCase
     {
         $tag = new Tag\Item(['title' => 'foo', 'weight' => 1]);
         $tag->setOptions([
-            'title' => 'bar',
+            'title'  => 'bar',
             'weight' => 10,
             'params' => [
-                'bar' => 'baz'
-            ]
+                'bar' => 'baz',
+            ],
         ]);
 
         $this->assertEquals('bar', $tag->getTitle());
@@ -63,7 +60,7 @@ class ItemTest extends TestCase
 
     public function testInvalidTitle()
     {
-        $this->expectException('\Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Title must be a string');
         $tag = new Tag\Item(['title' => 10, 'weight' => 1]);
     }
@@ -79,7 +76,7 @@ class ItemTest extends TestCase
 
     public function testInvalidWeight()
     {
-        $this->expectException('\Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Weight must be numeric');
         $tag = new Tag\Item(['title' => 'foo', 'weight' => 'foobar']);
     }
@@ -92,21 +89,21 @@ class ItemTest extends TestCase
 
     public function testInvalidOptions()
     {
-        $this->expectException('\Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid options provided to constructor');
         $tag = new Tag\Item('test');
     }
 
     public function testMissingTitle()
     {
-        $this->expectException('\Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Title was not set');
         $tag = new Tag\Item(['weight' => 1]);
     }
 
     public function testMissingWeight()
     {
-        $this->expectException('\Laminas\Tag\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Weight was not set');
         $tag = new Tag\Item(['title' => 'foo']);
     }


### PR DESCRIPTION
This patch provides PHP 8.1 support, and removes support for PHP 7.3.

To accomplish it, it updates to the laminas-coding-standard 2.3 ruleset and applies it, updates dependencies to those know to work with 8.1, and adds the `#[ReturnTypeWillChange]` attribute to methods in the `ItemList` definition.
