### PR TITLE
Fix: Allow `dealerdirect/phpcodesniffer-composer-installer` to run as `composer` plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true
     },
     "require": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This pull request

- [x] allows `dealerdirect/phpcodesniffer-composer-installer` to run as `composer` plugin 