### PR TITLE
Fix: Method should be `static`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0",
+        "php": "~8.1.0",
         "laminas/laminas-escaper": "^2.9",
         "laminas/laminas-stdlib": "^3.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0",
         "laminas/laminas-escaper": "^2.9",
         "laminas/laminas-stdlib": "^3.6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b26c29329b22596f953acc1ce59548e7",
+    "content-hash": "cf19e17ff5b68621f6730695461ffa95",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -2743,8 +2743,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0"
+        "php": "~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf19e17ff5b68621f6730695461ffa95",
+    "content-hash": "9a8d067b13f4c6a3097038033742daa4",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -2743,7 +2743,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0"
+        "php": "~8.1.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"

--- a/test/Cloud/Decorator/DecoratorPluginManagerCompatibilityTest.php
+++ b/test/Cloud/Decorator/DecoratorPluginManagerCompatibilityTest.php
@@ -19,7 +19,7 @@ class DecoratorPluginManagerCompatibilityTest extends TestCase
     use CommonPluginManagerTrait;
 
     /** @return DecoratorPluginManager */
-    protected function getPluginManager()
+    protected static function getPluginManager()
     {
         return new DecoratorPluginManager(new ServiceManager());
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This pull request

- [x] marks a method that overrides a `static` method as `static`

Blocked by #13.
Blocked by #15.
Blocks #11.
