### PR TITLE
Fix: Drop support for PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0",
         "laminas/laminas-escaper": "^2.9",
         "laminas/laminas-stdlib": "^3.6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b26c29329b22596f953acc1ce59548e7",
+    "content-hash": "cf19e17ff5b68621f6730695461ffa95",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -2743,8 +2743,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0"
+        "php": "~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | yes/no
| BC Break      | yes/no
| New Feature   | yes/no
| RFC           | yes/no
| QA            | yes/no

### Description

This pull request

- [x] drops support for PHP 7.4

Related to #11.